### PR TITLE
Add CosigneeName from response

### DIFF
--- a/lib/address_validator/address.rb
+++ b/lib/address_validator/address.rb
@@ -24,6 +24,7 @@ module AddressValidator
         address_lines = Array(attrs['AddressLine'])
 
         new(
+          name: attrs['ConsigneeName'],
           street1: address_lines[0],
           street2: address_lines[1],
           street3: address_lines[2],

--- a/spec/data/vcr_cassettes/ambiguous-address.yml
+++ b/spec/data/vcr_cassettes/ambiguous-address.yml
@@ -6,17 +6,23 @@ http_interactions:
     body:
       encoding: UTF-8
       string: <?xml version="1.0" encoding="UTF-8"?><AccessRequest><AccessLicenseNumber>%{AccessLicenseNumber}</AccessLicenseNumber><UserId>%{UserId}</UserId><Password>%{Password}</Password></AccessRequest><?xml
-        version="1.0" encoding="UTF-8"?><AddressValidationRequest><Request><RequestAction>XAV</RequestAction><RequestOption>3</RequestOption></Request><MaximumListSize>5</MaximumListSize><AddressKeyFormat><ConsigneeName>Brady
+        version="1.0" encoding="UTF-8"?><AddressValidationRequest><Request><RequestAction>XAV</RequestAction><RequestOption>3</RequestOption></Request><MaximumListSize>1</MaximumListSize><AddressKeyFormat><ConsigneeName>Brady
         Somerville</ConsigneeName><AddressLine>Nashville Rd</AddressLine><PoliticalDivision2>Bowling
-        Green</PoliticalDivision2><PoliticalDivision1>KY</PoliticalDivision1><PostcodePrimaryLow>42104</PostcodePrimaryLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationRequest>
-    headers: {}
+        Green</PoliticalDivision2><PoliticalDivision1>KY</PoliticalDivision1><PostcodePrimaryLow>42104</PostcodePrimaryLow><PostcodeExtendedLow/><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationRequest>
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 12 Jun 2014 18:42:27 GMT
+      - Tue, 05 Apr 2016 12:20:41 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -24,22 +30,16 @@ http_interactions:
       Pragma:
       - no-cache
       Content-Length:
-      - '2584'
+      - '808'
+      X-Content-Type-Options:
+      - nosniff
       Content-Type:
       - application/xml
     body:
       encoding: UTF-8
       string: <?xml version="1.0"?><AddressValidationResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><AmbiguousAddressIndicator/><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>1-99
         NASHVILLE RD</AddressLine><Region>BOWLING GREEN KY 42101-3800</Region><PoliticalDivision2>BOWLING
-        GREEN</PoliticalDivision2><PoliticalDivision1>KY</PoliticalDivision1><PostcodePrimaryLow>42101</PostcodePrimaryLow><PostcodeExtendedLow>3800</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>6100-6299
-        NASHVILLE RD</AddressLine><Region>BOWLING GREEN KY 42101-7514</Region><PoliticalDivision2>BOWLING
-        GREEN</PoliticalDivision2><PoliticalDivision1>KY</PoliticalDivision1><PostcodePrimaryLow>42101</PostcodePrimaryLow><PostcodeExtendedLow>7514</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>6400-6550
-        NASHVILLE RD</AddressLine><Region>BOWLING GREEN KY 42101-7548</Region><PoliticalDivision2>BOWLING
-        GREEN</PoliticalDivision2><PoliticalDivision1>KY</PoliticalDivision1><PostcodePrimaryLow>42101</PostcodePrimaryLow><PostcodeExtendedLow>7548</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>6551-6599
-        NASHVILLE RD</AddressLine><Region>BOWLING GREEN KY 42101-7547</Region><PoliticalDivision2>BOWLING
-        GREEN</PoliticalDivision2><PoliticalDivision1>KY</PoliticalDivision1><PostcodePrimaryLow>42101</PostcodePrimaryLow><PostcodeExtendedLow>7547</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat><AddressKeyFormat><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification><AddressLine>6600-6699
-        NASHVILLE RD</AddressLine><Region>BOWLING GREEN KY 42101-7518</Region><PoliticalDivision2>BOWLING
-        GREEN</PoliticalDivision2><PoliticalDivision1>KY</PoliticalDivision1><PostcodePrimaryLow>42101</PostcodePrimaryLow><PostcodeExtendedLow>7518</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationResponse>
+        GREEN</PoliticalDivision2><PoliticalDivision1>KY</PoliticalDivision1><PostcodePrimaryLow>42101</PostcodePrimaryLow><PostcodeExtendedLow>3800</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationResponse>
     http_version: 
-  recorded_at: Thu, 12 Jun 2014 18:42:27 GMT
+  recorded_at: Tue, 05 Apr 2016 12:20:41 GMT
 recorded_with: VCR 2.4.0

--- a/spec/data/vcr_cassettes/invalid-address.yml
+++ b/spec/data/vcr_cassettes/invalid-address.yml
@@ -8,12 +8,12 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><AccessRequest><AccessLicenseNumber>%{AccessLicenseNumber}</AccessLicenseNumber><UserId>%{UserId}</UserId><Password>%{Password}</Password></AccessRequest><?xml
         version="1.0" encoding="UTF-8"?><AddressValidationRequest><Request><RequestAction>XAV</RequestAction><RequestOption>3</RequestOption></Request><MaximumListSize>1</MaximumListSize><AddressKeyFormat><ConsigneeName>Doctor
         Daves Backyard Dentistry</ConsigneeName><AddressLine>1 Seseme Street</AddressLine><PoliticalDivision2>New
-        York</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10012</PostcodePrimaryLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationRequest>
+        York</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10012</PostcodePrimaryLow><PostcodeExtendedLow/><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationRequest>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
   response:
@@ -22,7 +22,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 15 Nov 2015 00:36:42 GMT
+      - Tue, 05 Apr 2016 12:20:42 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -39,5 +39,5 @@ http_interactions:
       encoding: UTF-8
       string: <?xml version="1.0"?><AddressValidationResponse><Response><TransactionReference></TransactionReference><ResponseStatusCode>1</ResponseStatusCode><ResponseStatusDescription>Success</ResponseStatusDescription></Response><NoCandidatesIndicator/><AddressClassification><Code>0</Code><Description>Unknown</Description></AddressClassification></AddressValidationResponse>
     http_version: 
-  recorded_at: Sun, 15 Nov 2015 00:36:42 GMT
+  recorded_at: Tue, 05 Apr 2016 12:20:42 GMT
 recorded_with: VCR 2.4.0

--- a/spec/data/vcr_cassettes/valid-address-hash.yml
+++ b/spec/data/vcr_cassettes/valid-address-hash.yml
@@ -8,12 +8,12 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><AccessRequest><AccessLicenseNumber>%{AccessLicenseNumber}</AccessLicenseNumber><UserId>%{UserId}</UserId><Password>%{Password}</Password></AccessRequest><?xml
         version="1.0" encoding="UTF-8"?><AddressValidationRequest><Request><RequestAction>XAV</RequestAction><RequestOption>3</RequestOption></Request><MaximumListSize>1</MaximumListSize><AddressKeyFormat><ConsigneeName>Yum</ConsigneeName><AddressLine>33
         St. Marks Place</AddressLine><AddressLine>Suite 3</AddressLine><AddressLine>C/O
-        Some Dude</AddressLine><PoliticalDivision2>New York</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10003</PostcodePrimaryLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationRequest>
+        Some Dude</AddressLine><PoliticalDivision2>New York</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10003</PostcodePrimaryLow><PostcodeExtendedLow/><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationRequest>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
   response:
@@ -22,7 +22,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 15 Nov 2015 00:36:44 GMT
+      - Tue, 05 Apr 2016 12:20:38 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -41,5 +41,5 @@ http_interactions:
         ST MARKS PL</AddressLine><AddressLine>APT 3</AddressLine><Region>NEW YORK
         NY 10003-7832</Region><PoliticalDivision2>NEW YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10003</PostcodePrimaryLow><PostcodeExtendedLow>7832</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationResponse>
     http_version: 
-  recorded_at: Sun, 15 Nov 2015 00:36:43 GMT
+  recorded_at: Tue, 05 Apr 2016 12:20:38 GMT
 recorded_with: VCR 2.4.0

--- a/spec/data/vcr_cassettes/valid-address.yml
+++ b/spec/data/vcr_cassettes/valid-address.yml
@@ -8,12 +8,12 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><AccessRequest><AccessLicenseNumber>%{AccessLicenseNumber}</AccessLicenseNumber><UserId>%{UserId}</UserId><Password>%{Password}</Password></AccessRequest><?xml
         version="1.0" encoding="UTF-8"?><AddressValidationRequest><Request><RequestAction>XAV</RequestAction><RequestOption>3</RequestOption></Request><MaximumListSize>1</MaximumListSize><AddressKeyFormat><ConsigneeName>Yum</ConsigneeName><AddressLine>33
         St. Marks Place</AddressLine><AddressLine>Suite 3</AddressLine><PoliticalDivision2>New
-        York</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10003</PostcodePrimaryLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationRequest>
+        York</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10003</PostcodePrimaryLow><PostcodeExtendedLow/><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationRequest>
     headers:
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
-      - '*/*'
+      - "*/*"
       User-Agent:
       - Ruby
   response:
@@ -22,7 +22,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Sun, 15 Nov 2015 00:36:41 GMT
+      - Tue, 05 Apr 2016 12:20:39 GMT
       Server:
       - Apache
       X-Frame-Options:
@@ -41,5 +41,5 @@ http_interactions:
         ST MARKS PL</AddressLine><AddressLine>APT 3</AddressLine><Region>NEW YORK
         NY 10003-7832</Region><PoliticalDivision2>NEW YORK</PoliticalDivision2><PoliticalDivision1>NY</PoliticalDivision1><PostcodePrimaryLow>10003</PostcodePrimaryLow><PostcodeExtendedLow>7832</PostcodeExtendedLow><CountryCode>US</CountryCode></AddressKeyFormat></AddressValidationResponse>
     http_version: 
-  recorded_at: Sun, 15 Nov 2015 00:36:41 GMT
+  recorded_at: Tue, 05 Apr 2016 12:20:40 GMT
 recorded_with: VCR 2.4.0

--- a/spec/lib/address_validator/address_spec.rb
+++ b/spec/lib/address_validator/address_spec.rb
@@ -83,6 +83,7 @@ describe AddressValidator::Address do
               <Description>Commercial</Description>
             </AddressClassification>
             <AddressLine>648 BROADWAY</AddressLine>
+            <ConsigneeName>Yum</ConsigneeName>
             <Region>NEW YORK NY 10012-2348</Region>
             <PoliticalDivision2>NEW YORK</PoliticalDivision2>
             <PoliticalDivision1>NY</PoliticalDivision1>
@@ -95,6 +96,7 @@ describe AddressValidator::Address do
 
       subject(:address){ described_class.from_xml(xml['AddressKeyFormat']) }
 
+      its(:name){ should eq 'Yum' }
       its(:street1){ should eq '648 BROADWAY' }
       its(:street2){ should be_nil }
       its(:street3){ should be_nil }
@@ -116,6 +118,7 @@ describe AddressValidator::Address do
             <AddressLine>648 BROADWAY</AddressLine>
             <AddressLine>SUITE 1</AddressLine>
             <AddressLine>C/O SOME GUY</AddressLine>
+            <ConsigneeName>Yum</ConsigneeName>
             <Region>NEW YORK NY 10012-2348</Region>
             <PoliticalDivision2>NEW YORK</PoliticalDivision2>
             <PoliticalDivision1>NY</PoliticalDivision1>
@@ -128,6 +131,7 @@ describe AddressValidator::Address do
 
       subject(:address){ described_class.from_xml(xml['AddressKeyFormat']) }
 
+      its(:name){ should eq 'Yum' }
       its(:street1){ should eq '648 BROADWAY' }
       its(:street2){ should eq 'SUITE 1' }
       its(:street3){ should eq 'C/O SOME GUY' }


### PR DESCRIPTION
REF: #7 - Adding the name back into the address.

According to the API docs the address should have a `CosigneeName` attribute returned, however, I can't seem to make this happen from my limited testing. If I mock the response it does get added back into the address though.
### Changes
- If `CosigneeName` comes back, add it into the `Address`.
